### PR TITLE
Remove double percent sign in stylesheet

### DIFF
--- a/cv/style.sass
+++ b/cv/style.sass
@@ -118,6 +118,6 @@ a
 
     .infowrapper
       float: left
-      width: 75%%
+      width: 75%
 
 


### PR DESCRIPTION
It causes the width rule to be ignored.
